### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the public repo for TETinderPageView, an emulation of the page-view styl
 ![](/img/demo.gif)
 
 <h3>Installation</h3>
-The controller can be easily installed to a project using the amazing [Cocoapods](https://cocoapods.org). Simply add this line to your podfile and run ```pod install```:
+The controller can be easily installed to a project using the amazing [CocoaPods](https://cocoapods.org). Simply add this line to your podfile and run ```pod install```:
 <br>
 <br>
  ```pod 'TETinderPageView'```


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
